### PR TITLE
Remove AC_PREREQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.deps/
+.libs/
+autom4te.cache/
+Makefile
+libtool
+stamp-h1
+
+*.la
+*.lo
+*.o
+*.log
+*.status
+

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,3 @@
-AC_PREREQ(2.65)
 AC_INIT([libaesrand], [0.1.0], [bcarmer@gmail.com])
 
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
I believe AC_PREREQ is causing issues with Ubuntu 14.04, where aclocal-1.14 is installed (instead of aclocal-1.15), so I removed it.
